### PR TITLE
fix wildcard cookie

### DIFF
--- a/handle.go
+++ b/handle.go
@@ -408,7 +408,7 @@ func validateHandle(w http.ResponseWriter, r *http.Request) {
 			Value:    id,
 			Expires:  expires,
 			MaxAge:   int(expires.Unix() - time.Now().Unix()),
-			Secure:   false,
+			Secure:   isHTTPS(r.Header),
 			HttpOnly: false,
 			SameSite: http.SameSiteNoneMode,
 		})
@@ -418,7 +418,7 @@ func validateHandle(w http.ResponseWriter, r *http.Request) {
 			Value:    id,
 			Expires:  expires,
 			MaxAge:   int(expires.Unix() - time.Now().Unix()),
-			Secure:   false,
+			Secure:   isHTTPS(r.Header),
 			HttpOnly: true,
 			SameSite: http.SameSiteStrictMode,
 		})

--- a/headers.go
+++ b/headers.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+)
+
+func isHTTPS(h http.Header) bool {
+	return strings.EqualFold(h.Get("X-Scheme"), "https")
+}

--- a/nginx/captcha_server.conf
+++ b/nginx/captcha_server.conf
@@ -15,6 +15,8 @@ location = /auth {
   proxy_set_header X-Forwarded-Host $host;
   proxy_set_header X-Original-URI $request_uri;
   proxy_set_header X-Real-IP $remote_addr;
+  # If you want to set wildcard cookies, add X-TLDPlusOne header. Works with https only.
+  # proxy_set_header X-TLDPlusOne "TRUE";
 
   proxy_http_version 1.1;
 
@@ -51,8 +53,11 @@ location @captcha {
   proxy_set_header X-Forwarded-Host $server_name;
   proxy_set_header X-Original-URI $request_uri;
   proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Scheme $scheme;
   # If you want to get only captcha image, add X-LiteTemplate header.
   # proxy_set_header X-LiteTemplate "TRUE";
+  # If you want to set wildcard cookies, add X-TLDPlusOne header. Works with https only.
+  # proxy_set_header X-TLDPlusOne "TRUE";
 
   add_header Cache-Control "no-cache, no-store, must-revalidate, proxy-revalidate, max-age=0";
 


### PR DESCRIPTION
SameSite=None requires the Secure attribute in latest browser versions.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#:~:text=The%20warning%20appears%20because%20any,marked%20Secure%20will%20be%20rejected.&text=To%20fix%20this%2C%20you%20will,to%20your%20SameSite%3DNone%20cookies.&text=A%20Secure%20cookie%20is%20only,request%20over%20the%20HTTPS%20protocol